### PR TITLE
Fix: Attempt to resolve right-half wakeup issue on Nebular

### DIFF
--- a/boards/shields/nebular/nebular_right.overlay
+++ b/boards/shields/nebular/nebular_right.overlay
@@ -77,7 +77,6 @@
         cpi = <800>; // Set Counts Per Inch (adjust as needed)
 
         status = "okay";
-        force-awake;
         wakeup-source;
 
         // Standard HID event codes


### PR DESCRIPTION
Removes the `force-awake;` property from the PMW3610 trackball configuration in the `nebular_right.overlay` file.

The `force-awake;` property might have been preventing the sensor or the microcontroller from entering a proper sleep state or interfering with the wakeup mechanism when on battery power. The `wakeup-source;` property is retained, which should allow the trackball to wake the device.

This change is intended to address an issue where the right half of the Nebular keyboard fails to wake from sleep on battery power until USB power is connected.