### PR TITLE
Fix PMW3610 SPI pinctrl configuration for bidirectional SDIO

### DIFF
--- a/boards/shields/nebular/nebular.keymap
+++ b/boards/shields/nebular/nebular.keymap
@@ -107,7 +107,7 @@
             bindings = <
                 &none       &none                  &none       &none      &none        &kp PG_DN         &kp PG_UP    &kp UP        &kp HOME     &kp END
                 &none       &kp LC(LA(LS(LG(T))))  &kp LG(K)   &trans     &none        &kp LG(LS(LBKT))  &kp LEFT     &kp DOWN      &kp RIGHT    &kp LG(LS(RBKT))
-                &none       &none                  &none       &none      &none        &caps_word        &kp LG(LBKT)) &kp LG(LS(X)) &kp LG(RBKT)) &none
+                &none       &none                  &none       &none      &none        &caps_word        &kp LG(LBKT) &kp LG(LS(X)) &kp LG(RBKT) &none
                                                    &none       &kp ESC                 &kp DEL     &trans
             >;
         };

--- a/boards/shields/nebular/nebular_right.overlay
+++ b/boards/shields/nebular/nebular_right.overlay
@@ -37,7 +37,7 @@
             // NRF_PSEL(peripheral, port, pin)
             psels = <NRF_PSEL(SPIM_SCK, 0, 24)>,  // P0.24 for SCK
                     <NRF_PSEL(SPIM_MOSI, 1, 0)>,  // P1.00 for MOSI/SDIO
-                    <NRF_PSEL(SPIM_MISO, 0, 23)>;  // Dummy MISO pin (unused wire)
+                    <NRF_PSEL(SPIM_MISO, 1, 0)>;  // P1.00 for MISO/SDIO (same pin - bidirectional)
             // Make sure to properly drive MOSI/MISO - required for shared SDIO
             nordic,drive-mode = <NRF_DRIVE_H0H1>;
         };
@@ -47,7 +47,7 @@
         group1 {
             psels = <NRF_PSEL(SPIM_SCK, 0, 24)>,
                     <NRF_PSEL(SPIM_MOSI, 1, 0)>,
-                    <NRF_PSEL(SPIM_MISO, 0, 23)>;
+                    <NRF_PSEL(SPIM_MISO, 1, 0)>;  // P1.00 for MISO/SDIO (same pin - bidirectional)
             low-power-enable;
         };
     };


### PR DESCRIPTION
## Problem
The PMW3610 trackball sensor was failing to initialize with the error:
```
[00:00:01.564,422] <err> pmw3610: Incorrect product id 0xff (expecting 0x3e)!
[00:00:01.564,422] <err> pmw3610: PMW3610 initialization failed in step 2
```

Reading `0xff` instead of the expected `0x3e` indicates SPI communication failure.

## Root Cause
The pinctrl configuration had separate MOSI and MISO pins:
- MOSI: P1.00 (correct)  
- MISO: P0.23 (incorrect)

However, the PMW3610 uses a **single bidirectional SDIO pin** for both data input and output, not separate MOSI/MISO lines.

## Solution
Updated both `spi0_default` and `spi0_sleep` pinctrl configurations to use P1.00 for both MOSI and MISO, matching the actual hardware design where SDIO handles bidirectional communication.

## Expected Result
After this fix, the PMW3610 should:
1. Read the correct product ID (0x3e) during initialization
2. Complete all initialization steps successfully  
3. Generate motion events when the trackball is moved

## Testing
Flash the updated firmware and monitor USB logs - you should see successful PMW3610 initialization instead of the product ID error.